### PR TITLE
Update Dockerfile & fixed the trivy error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:alpine
+nginx:stable-perl
 COPY --from=build /app/dist /usr/share/nginx/html
 # Add nginx configuration if needed
 # COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Trivy vulnerability scanner Error Fixed:

Solution: 

Go to Dockerfile -> Change the tag of  nginx image as follows
FROM nginx:alpine  -> FROM nginx:stable-perl

Reason:
Trivy detected a HIGH severity vulnerability in the base image nginx:alpine, specifically related to the libxml2 library in Alpine OS.

