### PR TITLE
Update ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - 'kubernetes/deployment.yaml'  # Ignore changes to this file to prevent loops
+      - 'kubernetes/*'  # Ignore changes to this file to prevent loops
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
No need to trigger the pipeline for changes on any kubernetes manifest files. Currently only deployment.yaml file is ignored but ignoring all the manifest files will be a better option